### PR TITLE
Allow changing the default inputs and outputs names and input fixes

### DIFF
--- a/.github/action/action.yml
+++ b/.github/action/action.yml
@@ -1,0 +1,46 @@
+# action.yml
+name: 'Badge Action'
+author: 'emibcn'
+description: 'Create a SVG badge using GitHub Actions and GitHub Workflow CPU time (no 3rd parties servers)'
+branding:
+  icon: award
+  color: blue
+inputs:
+  label:
+    description: 'The left label of the badge, usually static.'
+    required: true
+  label-color:
+    description: 'Hex or named color for the label'
+    required: true
+    default: '555'
+  status:
+    description: 'The right status as the badge, usually based on results.'
+    required: true
+  color:
+    description: 'An array (comma separated) with hex or named colors of the badge value background. More than one creates gradient background.'
+    required: true
+    default: 'blue'
+  style:
+    description: 'Badge style: flat or classic'
+    required: true
+    default: 'classic'
+  icon:
+    description: 'Use icon'
+    required: false
+  icon-width:
+    description: 'Set this if icon is not square'
+    required: false
+    default: 13
+  scale:
+    description: 'Set badge scale'
+    required: true
+    default: 1
+  path:
+    description: 'The file path to store the badge image file. Only output to `badge` action output if undefined.'
+    required: false
+outputs:
+  badge:
+    description: 'The badge SVG contents'
+runs:
+  using: 'node12'
+  main: './dist/index.js'

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -53,11 +53,19 @@ jobs:
 
     - name: yarn install and test
       id: test
-      working-directory: ./
       run: |
-        yarn install
-        # Disabled exit until we reach at least 50% coverage
+        yarn --immutable --color
         yarn test
+        mkdir badges
+        cp -parv ./dist/ .github/action/
+
+    - name: Generate test badge using current code
+      uses: ./.github/action
+      with:
+        label: 'Tested'
+        status: 'true'
+        color: 'green'
+        path: badges/tested.svg
 
     # Coverage badges will be updated on any branch
     # and saved into a dedicated one

--- a/README.md
+++ b/README.md
@@ -19,51 +19,129 @@ yarn add github-badge-action
 
 ## Usage
 
-```
-const createBadgeFromInputs = require('github-badge-action');
+```javascript
+const { createBadgeFromInputs } = require('github-badge-action');
 createBadgeFromInputs();
 ```
 
 ## Inputs
 
-### `label`
+Inputs are read from action's inputs using `core.input`, fixed and passed directly to `gradient-badge`.
+
+### Change input names
+The input names are taken from `createBadgeFromInputs`'s `inputMap` argument, which has this deafults:
+```javascript
+const defaultInputMap = {
+  label: 'label',
+  labelColor: 'label-color',
+  status: 'status',
+  gradient: 'color',
+  style: 'style',
+  icon: 'icon',
+  iconWidth: 'icon-width',
+  scale: 'scale',
+  path: 'path',
+};
+```
+
+You can import it and modify just some of the options names:
+```javascript
+const {
+  createBadgeFromInputs,
+  defaultInputMap
+} = require('github-badge-action');
+
+createBadgeFromInputs({
+  inputMap: {
+    ...defaultOptionsMap,
+    gradient: 'gradient',
+    path: 'file',
+  },
+));
+```
+
+### Change input fixes
+Once the inputs are read, some **fixes are applied**. The default ones are:
+```javascript
+const defaultInputFixes = {
+  // Ensure string
+  status: (status) => `${status}`,
+
+  // Ensure null if empty
+  icon: (icon) => icon?.length ? icon : null,
+
+  // Color gradient as Array
+  gradient: (gradient) => gradient
+      .split(',')
+      // Clean spaces
+      .map((color) => color.trim(' ')),
+};
+```
+
+You can also change the fixes applied to the inputs, or add more using `inputFixes` option:
+```javascript
+const {
+  createBadgeFromInputs,
+  defaultInputFixes
+} = require('github-badge-action');
+
+createBadgeFromInputs({
+  inputFixes: {
+    ...defaultInputFixes,
+    // Color gradient as Array, split with a pipe '|' instead of a comma ','
+    gradient: (gradient) => gradient
+        .split('|')
+        // Clean spaces
+        .map((color) => color.trim(' ')),
+    },
+));
+```
+
+### Available options
+#### `label`
 
 **Required** The left label of the badge, usually static.
 
-### `label-color`
+#### `label-color`
 
 **Required** Hex or named color for the label. Default: `555`
 
-### `status`
+#### `status`
 
 **Required** The right status as the badge, usually based on results.
 
-### `color`
+#### `color`
 
 **Required** An array (comma separated) with hex or named colors of the badge value background. More than one creates gradient background. Default: `blue`.
 
-### `style`
+#### `style`
 
 **Required** Badge style: flat or classic. Default: `classic`
 
-### `icon`
+#### `icon`
 
 Use icon.
 
-### `icon-width`
+#### `icon-width`
 
 Set this if icon is not square. Default: `13`
 
-### `scale`
+#### `scale`
 
 Set badge scale. Default: `1`
 
-### `path`
+#### `path`
 
 The file path to store the badge image file. Only output to `badge` action output if not defined.
 
 ## Outputs
 
 ### `badge`
+Once the badge is generated, the SVG contents are written to an action output (by default). Tha name of the output can be modified using `outputName` option:
+```javascript
+createBadgeFromInputs({
+  outputName: 'badge-svg-custom'
+});
+```
 
-The badge SVG contents.
+If the option is `null` or empty, **output will not be written**. The default option name is `badge`.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The file path to store the badge image file. Only output to `badge` action outpu
 ## Outputs
 
 ### `badge`
-Once the badge is generated, the SVG contents are written to an action output (by default). Tha name of the output can be modified using `outputName` option:
+Once the badge is generated, the SVG contents are written to an action output (by default). The name of the output can be modified using `outputName` option:
 ```javascript
 createBadgeFromInputs({
   outputName: 'badge-svg-custom'

--- a/src/defaultInputFixes.js
+++ b/src/defaultInputFixes.js
@@ -1,0 +1,17 @@
+const defaultInputFixes = {
+  // Ensure string
+  status: (status) => `${status}`,
+
+  // Ensure null if empty
+  icon: (icon) => (icon?.length ? icon : null),
+
+  // Color gradient as Array
+  gradient: (gradient) =>
+    gradient
+      .split(',')
+
+      // Clean spaces
+      .map((color) => color.trim(' ')),
+};
+
+export default defaultInputFixes;

--- a/src/defaultInputMap.js
+++ b/src/defaultInputMap.js
@@ -1,0 +1,13 @@
+const defaultInputMap = {
+  label: 'label',
+  labelColor: 'label-color',
+  status: 'status',
+  gradient: 'color',
+  style: 'style',
+  icon: 'icon',
+  iconWidth: 'icon-width',
+  scale: 'scale',
+  path: 'path',
+};
+
+export default defaultInputMap;

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ const createBadgeFromInputs = ({
     }
 
     // If path is defined, save SVG data to that file
-    if (path && path.length) {
+    if (path?.length) {
       console.log(`Write data to file ${path}...`);
 
       // In case an error occurred writing file,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,10 @@
 import { createBadgeFromInputs } from './index';
 
 it('Does not crash', () => {
-  createBadgeFromInputs();
+  createBadgeFromInputs({
+    inputFixes: {
+      gradient: () => 'green',
+      status: () => 'true',
+    },
+  });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-import createBadgeFromInputs from './index';
+import { createBadgeFromInputs } from './index';
 
 it('Does not crash', () => {
   createBadgeFromInputs();


### PR DESCRIPTION
Allow changing the default inputs and outputs names and input fixes

Breaking change: Change how it is imported:
```javascript
const { createBadgeFromInputs } = require('github-badge-action');
```

New functionality and documentation:

## Usage

```javascript
const { createBadgeFromInputs } = require('github-badge-action');
createBadgeFromInputs();
```

## Inputs

Inputs are read from action's inputs using `core.input`, fixed and passed directly to `gradient-badge`.

### Change input names
The input names are taken from `createBadgeFromInputs`'s `inputMap` argument, which has this deafults:
```javascript
const defaultInputMap = {
  label: 'label',
  labelColor: 'label-color',
  status: 'status',
  gradient: 'color',
  style: 'style',
  icon: 'icon',
  iconWidth: 'icon-width',
  scale: 'scale',
  path: 'path',
};
```

You can import it and modify just some of the options names:
```javascript
const {
  createBadgeFromInputs,
  defaultInputMap
} = require('github-badge-action');

createBadgeFromInputs({
  inputMap: {
    ...defaultOptionsMap,
    gradient: 'gradient',
    path: 'file',
  },
));
```

### Change input fixes
Once the inputs are read, some **fixes are applied**. The default ones are:
```javascript
const defaultInputFixes = {
  // Ensure string
  status: (status) => `${status}`,

  // Ensure null if empty
  icon: (icon) => icon?.length ? icon : null,

  // Color gradient as Array
  gradient: (gradient) => gradient
      .split(',')
      // Clean spaces
      .map((color) => color.trim(' ')),
};
```

You can also change the fixes applied to the inputs, or add more using `inputFixes` option:
```javascript
const {
  createBadgeFromInputs,
  defaultInputFixes
} = require('github-badge-action');

createBadgeFromInputs({
  inputFixes: {
    ...defaultInputFixes,
    // Color gradient as Array, split with a pipe '|' instead of a comma ','
    gradient: (gradient) => gradient
        .split('|')
        // Clean spaces
        .map((color) => color.trim(' ')),
    },
));
```
